### PR TITLE
feat(alerts) added variant and color for buttons options

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ dialog.alert('Warning!')
 * `options` (object|string) – The alert dialog settings. If `options` is a string, set dialog message to display.
 * `options.title` (string) – The dialog title to display.
 * `options.message` (string) – The dialog message to display.
-* `options.ok` (string) - The positive button text to display. Default `OK`.
+* `options.ok` (object) { text, color, variant } - The positive button text to display, color and variant, following mateiral-ui types. Defaults `OK`, `primary` and `text` respectively.
 
 ### Confirm
 
@@ -99,8 +99,8 @@ dialog.confirm('Are you sure?')
 * `options` (object|string) – The confirm dialog settings. If `options` is a string, set dialog message to display.
 * `options.title` (string) – The dialog title to display.
 * `options.message` (string) – The dialog message to display.
-* `options.ok` (string) - The positive button text to display. Default `OK`.
-* `options.cancel` (string) - The negative button text to display. Default `Cancel`.
+* `options.ok` (object) { text, color, variant } - The positive button text to display, color and variant, following mateiral-ui types. Defaults `OK`, `primary` and `text` respectively.
+* `options.cancel` (object) { text, color, variant } - The negative button text to display, color and variant, following mateiral-ui types. Default `Cancel`, `primary` and `text` respectively.
 
 ### Prompt
 
@@ -118,8 +118,8 @@ dialog.prompt('Enter your name:')
 * `options` (object|string) – The prompt dialog settings. If `options` is a string, set dialog message to display.
 * `options.title` (string) – The dialog title to display.
 * `options.message` (string) – The dialog message to display.
-* `options.ok` (string) - The positive button text to display. Default `OK`.
-* `options.cancel` (string) - The negative button text to display. Default `Cancel`.
+* `options.ok` (object) { text, color, variant } - The positive button text to display, color and variant, following mateiral-ui types. Defaults `OK`, `primary` and `text` respectively.
+* `options.cancel` (object) { text, color, variant } - The negative button text to display, color and variant, following mateiral-ui types. Default `Cancel`, `primary` and `text` respectively.
 * `options.required` (bool) - If `true`, the label is displayed as required and the input will be required. Default `false`.
 * `options.defaultValue` (string|number) - The default value of the `Input` element.
 

--- a/src/components/AlertDialog.js
+++ b/src/components/AlertDialog.js
@@ -23,7 +23,7 @@ function AlertDialog (props, context) {
         <DialogContentText id="alert-dialog-message">{message}</DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button onClick={() => onClose()} color="primary" autoFocus>{ok}</Button>
+        <Button onClick={() => onClose()} color={ok.color} variant={ok.variant} autoFocus>{ok.text}</Button>
       </DialogActions>
     </Dialog>
   )
@@ -35,13 +35,21 @@ AlertDialog.propTypes = {
   onExited: PropTypes.func.isRequired,
   title: PropTypes.string,
   message: PropTypes.node,
-  ok: PropTypes.string
+  ok: PropTypes.objectOf({
+    text: PropTypes.string,
+    color: PropTypes.string,
+    variant: PropTypes.string
+  }),
 }
 
 AlertDialog.defaultProps = {
   open: false,
   title: '',
-  ok: 'OK'
+  ok: {
+    text: 'OK',
+    color: 'primary',
+    variant: 'text'
+  }
 }
 
 export default AlertDialog

--- a/src/components/ConfirmDialog.js
+++ b/src/components/ConfirmDialog.js
@@ -23,8 +23,8 @@ function ConfirmDialog (props, context) {
         <DialogContentText id="confirm-dialog-message">{message}</DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button onClick={() => onClose(false)} color="primary">{cancel}</Button>
-        <Button onClick={() => onClose(true)} color="primary" autoFocus>{ok}</Button>
+        <Button onClick={() => onClose(false)} color={cancel.color} variant={cancel.variant}>{cancel.text}</Button>
+        <Button onClick={() => onClose(true)} color={ok.color} variant={ok.variant} autoFocus>{ok.text}</Button>
       </DialogActions>
     </Dialog>
   )
@@ -36,15 +36,31 @@ ConfirmDialog.propTypes = {
   onExited: PropTypes.func.isRequired,
   title: PropTypes.string,
   message: PropTypes.node,
-  ok: PropTypes.string,
-  cancel: PropTypes.string
+  ok: PropTypes.objectOf({
+    text: PropTypes.string,
+    color: PropTypes.string,
+    variant: PropTypes.string
+  }),
+  cancel: PropTypes.objectOf({
+    text: PropTypes.string,
+    color: PropTypes.string,
+    variant: PropTypes.string
+  }),
 }
 
 ConfirmDialog.defaultProps = {
   open: false,
   title: '',
-  ok: 'OK',
-  cancel: 'Cancel'
+  ok: {
+    text: 'OK',
+    color: 'primary',
+    variant: 'text'
+  },
+  cancel: {
+    text: 'Cancel',
+    color: 'primary',
+    variant: 'text'
+  },
 }
 
 export default ConfirmDialog

--- a/src/components/PromptDialog.js
+++ b/src/components/PromptDialog.js
@@ -34,8 +34,8 @@ function PromptDialog (props, context) {
         />
       </DialogContent>
       <DialogActions>
-        <Button onClick={() => onClose(null)} color="primary">{cancel}</Button>
-        <Button onClick={() => onClose(value)} color="primary" disabled={required && !value}>{ok}</Button>
+        <Button onClick={() => onClose(null)} color={cancel.color} variant={cancel.variant}>{cancel.text}</Button>
+        <Button onClick={() => onClose(value)} color={ok.color} variant={ok.variant} disabled={required && !value}>{ok.text}</Button>
       </DialogActions>
     </Dialog>
   )
@@ -47,8 +47,16 @@ PromptDialog.propTypes = {
   onExited: PropTypes.func.isRequired,
   title: PropTypes.string,
   message: PropTypes.node,
-  ok: PropTypes.string,
-  cancel: PropTypes.string,
+  ok: PropTypes.objectOf({
+    text: PropTypes.string,
+    color: PropTypes.string,
+    variant: PropTypes.string
+  }),
+  cancel: PropTypes.objectOf({
+    text: PropTypes.string,
+    color: PropTypes.string,
+    variant: PropTypes.string
+  }),
   required: PropTypes.bool,
   defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   value: PropTypes.string,
@@ -58,8 +66,16 @@ PromptDialog.propTypes = {
 PromptDialog.defaultProps = {
   open: false,
   title: '',
-  ok: 'OK',
-  cancel: 'Cancel',
+  ok: {
+    text: 'OK',
+    color: 'primary',
+    variant: 'text'
+  },
+  cancel: {
+    text: 'Cancel',
+    color: 'primary',
+    variant: 'text'
+  },
   required: false
 }
 

--- a/stories/index.js
+++ b/stories/index.js
@@ -20,6 +20,23 @@ storiesOf('Confirm', module)
     const options = { title: 'Confirm Dialog', message: 'This is confirm dialog message.' }
     return <Confirm options={options} />
   })
+  .add('changing button color and variant', () => {
+    const options = {
+      title: 'Confirm Dialog',
+      message: 'This is confirm dialog message.',
+      ok: {
+        text: `Yes`,
+        color: `primary`,
+        variant: `contained`
+      },
+      cancel: {
+        text: `No`,
+        color: `secondary`,
+        variant: `outlined`
+      }
+    }
+    return <Confirm options={options} />
+  })
 
 storiesOf('Prompt', module)
   .addDecorator(story => <DialogProvider>{story()}</DialogProvider>)


### PR DESCRIPTION
Hello @chunkai1312 I created this pull request to be able to change the variant and color of buttons following the material-ui types for this props.
I using your Component so I'd think this props need to be customizable for a better UI/UX.